### PR TITLE
calculate available plots during the plotting

### DIFF
--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -88,13 +88,24 @@ foreach ($tmpDrive in $tmpDrives)
                 $PlotInProgressName = $activeJobs.PlotId
                 $PlotInProgressCount = $activeJobs.count
 
-                $AmountOfPlotsToTempMax = [math]::Floor(($FreeSpace / 290))
-
                 if ($PlotInProgressCount -eq $null)
                     {
                         $PlotInProgressCount = 1
                     }
-                $AvailableAmounToPlot = $AmountOfPlotsToTempMax - $PlotInProgressCount
+                
+                $RedundencyCheck = $DiskSize - ($FreeSpace + $PlotInProgressCount * 290)
+                #has addiontal data in the disk
+                if($RedundencyCheck -gt 0)
+                    {
+                        $AmountOfPlotsToTempMax = [math]::Floor(($FreeSpace / 290))
+                        $AvailableAmounToPlot = $AmountOfPlotsToTempMax - $PlotInProgressCount
+                    }
+                else
+                    {
+                        $AmountOfPlotsinProgressOccupied = [math]::Floor(($PlotInProgressCount * 290))
+                        $AvailableAmounToPlot = [math]::Floor(($DiskSize - $AmountOfPlotsinProgressOccupied) / 290)
+                        $AmountOfPlotsToTempMax = $AvailableAmounToPlot + $PlotInProgressCount
+                    }
 
             }
 


### PR DESCRIPTION
## Background
When there are some plots in the progress or exists some additional data in the temp disk, we should not calculate the available plots remaining directly from free space.

## Wrong behavior
It happens when I run `Start-PlotoSpawns` and there are some plots already in the progress.
```
PS C:\Users\fanyu\Downloads\Ploto-main\Ploto-main>  Get-PlotoTempDrives -TempDriveDenom "plot"


DriveLetter             : I:
ChiaDriveType           : Temp
VolumeName              : Chiaplot2
FreeSpace               : 395.13
TotalSpace              : 894.24
hasFolder               : False
IsPlottable             : False
HasPlotInProgress       : True
AmountOfPlotsInProgress : 3
AmountOfPlotsToTempMax  : 1
AvailableAmountToPlot   : -2

DriveLetter             : S:
ChiaDriveType           : Temp
VolumeName              : Chiaplot1
FreeSpace               : 579.59
TotalSpace              : 953.85
hasFolder               : False
IsPlottable             : False
HasPlotInProgress       : True
AmountOfPlotsInProgress : 3
AmountOfPlotsToTempMax  : 1
AvailableAmountToPlot   : -2
```
## Expect Behavior
```
DriveLetter             : I:
ChiaDriveType           : Temp
VolumeName              : Chiaplot2
FreeSpace               : 391.72
TotalSpace              : 894.24
hasFolder               : False
IsPlottable             : False
HasPlotInProgress       : True
AmountOfPlotsInProgress : 3
AmountOfPlotsToTempMax  : 3
AvailableAmountToPlot   : 0

DriveLetter             : S:
ChiaDriveType           : Temp
VolumeName              : Chiaplot1
FreeSpace               : 618.46
TotalSpace              : 953.85
hasFolder               : False
IsPlottable             : False
HasPlotInProgress       : True
AmountOfPlotsInProgress : 3
AmountOfPlotsToTempMax  : 3
AvailableAmountToPlot   : 0

```

## Workaround
### When there are some plots already in the progress.
1. If there is no additional data in the temp disk, indicating it is a pure plotting disk, checking by
`
$DiskSize < ($FreeSpace + $PlotInProgressCount * 290)
`
We should calculate the remaining available plot by 
`
($DiskSize - $AmountOfPlotsinProgressOccupied) / 290(Each temp file size)
`
2. If there is additional data in the temp disk, in order to avoid disk full risk, we should keep the previous calculation method.