### PR TITLE
Refactored core-logic and switch to config for params

### DIFF
--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -472,23 +472,6 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                             )
                                                         )
 
-
-                                                        $embedBuilder.AddField(
-                                                            [DiscordField]::New(
-                                                                'Total Jobs in Progress',
-                                                                $JobCountOut, 
-                                                                $true
-                                                            )
-                                                        )
-
-                                                        $embedBuilder.AddField(
-                                                            [DiscordField]::New(
-                                                                'Jobs on this temp disk',
-                                                                $JobCountSameOut, 
-                                                                $true
-                                                            )
-                                                        )
-
                                                         $embedBuilder.AddField(
                                                             [DiscordField]::New(
                                                                 'Max parallel Jobs in progress allowed',

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -1,0 +1,24 @@
+{
+    "IntervallToCheckInMinutes": "5",
+    "InputAmountToSpawn": "100", 
+    "EnableAlerts": "false",
+
+    "DiskConfig": [
+      {
+        "TempDriveDenom": "plot",
+        "OutDriveDenom": "out"
+      }
+    ],
+
+    "JobConfig": [
+        {
+          "WaitTimeBetweenPlotOnSeparateDisks": "15",
+          "WaitTimeBetweenPlotOnSameDisk": "30",
+          "MaxParallelJobsOnAllDisks": "8",
+          "MaxParallelJobsOnSameDisk": "3",
+          "BufferSize": "3390",
+          "Thread": "1",
+          "Bitfield": "true"
+        }
+      ]
+  }


### PR DESCRIPTION
## Changed

* Changed Corelogic of PlotoSpawner due to various issues. Removed much not necessary complexity. 74bbf33
    * It does not wait anymore for a given TempDrive to become plotable. It checks all TempDrives peridodically upon definable Intervall (default 5 min)
* Switched from Parameter to config file for controlling spawning
* Moved some Write-Hosts to Write-Verbose

## Added
* Some more detailled logging with -Verbose

## Fixed
* fixes #45 
* fixes #47

## Known Bugs
* #48 
-InputAmountToSpawn is blatantly ignored for now. Why? I focus on successfully spawning jobs as fast as possible rather than complying with that param. Overcommit should not possible anyway due to checking OutDrives. And also If a jobs fills a drive, you may copy/move stuff from on that drive and te job can continue. Will be fixed though!