### PR TITLE
plot to nvme first and pool plotting

### DIFF
--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.0.9.4.9.1
+Version: 1.0.9.4.9.2
 Author: Tydeno
 
 
@@ -691,7 +691,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                 }
                                            }
 
-                                    if ($FarmerKey -ne $null -or $FarmerKey -ne "")
+                                    if ($FarmerKey -ne "" -or $FarmerKey -ne " ")
                                         {
                                             #Lets check if its a Key
                                             $CharArray = $FarmerKey.ToCharArray()
@@ -704,7 +704,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
 
                                         }
 
-                                    if ($PoolKey -ne $null -or $PoolKey -ne "")
+                                    if ($PoolKey -ne "" -or $PoolKey -ne " ")
                                         {
                                             #Lets check if its a Key
                                             $CharArray = $PoolKey.ToCharArray()
@@ -717,7 +717,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
 
                                         }
 
-                                     if ($P2Singleton -ne $null -or $P2Singleton -ne "")
+                                     if ($P2Singleton -ne "" -or $P2Singleton -ne " ")
                                         {
                                             #Lets check if its a Key
                                             $CharArray = $P2Singleton.ToCharArray()

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.0.9.4.9
+Version: 1.0.9.4.9.1
 Author: Tydeno
 
 
@@ -382,7 +382,8 @@ function Invoke-PlotoJob
         $MaxParallelJobsInPhase1OnSameDisk,
         $MaxParallelJobsInPhase1OnAllDisks,
         $StartEarly,
-        $StartEarlyPhase
+        $StartEarlyPhase,
+        $P2Singleton
 		)
 
  if($verbose) {
@@ -711,6 +712,19 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                 {
                                                     Write-Verbose ("PlotoSpawner @ "+(Get-Date)+": This looks like a valid key based on its length")
                                                     $ExpandedArgs = "-p "+$PoolKey
+                                                    $ArgumentList = $ArgumentList+" "+$ExpandedArgs
+                                                }
+
+                                        }
+
+                                     if ($P2Singleton -ne $null -or $P2Singleton -ne "")
+                                        {
+                                            #Lets check if its a Key
+                                            $CharArray = $P2Singleton.ToCharArray()
+                                            if ($CharArray.Count -eq 96)
+                                                {
+                                                    Write-Verbose ("PlotoSpawner @ "+(Get-Date)+": This looks like a valid key based on its length")
+                                                    $ExpandedArgs = "-c "+$P2Singleton
                                                     $ArgumentList = $ArgumentList+" "+$ExpandedArgs
                                                 }
 
@@ -1070,6 +1084,7 @@ function Start-PlotoSpawns
     $StartEarly = $config.JobConfig.StartEarly
     $StartEarlyPhase = $config.JobConfig.StartEarlyPhase
     $EnableFy = $config.EnablePlotoFyOnStart
+    $P2Singleton = $config.JobConfig.P2SingletonAdress
 
 
     Write-Host "PlotoManager @"(Get-Date)": InputAmountToSpawn:" $InputAmountToSpawn
@@ -1112,11 +1127,11 @@ function Start-PlotoSpawns
 
         if ($verbose)
             {
-                $SpawnedPlots = Invoke-PlotoJob -BufferSize $BufferSize -Thread $Thread -OutDriveDenom $OutDriveDenom -TempDriveDenom $TempDriveDenom -EnableBitfield $EnableBitfield -WaitTimeBetweenPlotOnSeparateDisks $WaitTimeBetweenPlotOnSeparateDisks -WaitTimeBetweenPlotOnSameDisk $WaitTimeBetweenPlotOnSameDisk -MaxParallelJobsOnAllDisks $MaxParallelJobsOnAllDisks -MaxParallelJobsOnSameDisk $MaxParallelJobsOnSameDisk -EnableAlerts $EnableAlerts -InputAmountToSpawn $InputAmountToSpawn -CountSpawnedJobs $SpawnedCountOverall -T2Denom $t2denom -WindowStyle $WindowStyle -FarmerKey $FarmerKey -PoolKey $PoolKey -MaxParallelJobsInPhase1OnSameDisk $MaxParallelJobsInPhase1OnSameDisk -MaxParallelJobsInPhase1OnAllDisks $MaxParallelJobsInPhase1OnAllDisks -StartEarly $StartEarly -StartEarlyPhase $StartEarlyPhase -Verbose
+                $SpawnedPlots = Invoke-PlotoJob -BufferSize $BufferSize -Thread $Thread -OutDriveDenom $OutDriveDenom -TempDriveDenom $TempDriveDenom -EnableBitfield $EnableBitfield -WaitTimeBetweenPlotOnSeparateDisks $WaitTimeBetweenPlotOnSeparateDisks -WaitTimeBetweenPlotOnSameDisk $WaitTimeBetweenPlotOnSameDisk -MaxParallelJobsOnAllDisks $MaxParallelJobsOnAllDisks -MaxParallelJobsOnSameDisk $MaxParallelJobsOnSameDisk -EnableAlerts $EnableAlerts -InputAmountToSpawn $InputAmountToSpawn -CountSpawnedJobs $SpawnedCountOverall -T2Denom $t2denom -WindowStyle $WindowStyle -FarmerKey $FarmerKey -PoolKey $PoolKey -MaxParallelJobsInPhase1OnSameDisk $MaxParallelJobsInPhase1OnSameDisk -MaxParallelJobsInPhase1OnAllDisks $MaxParallelJobsInPhase1OnAllDisks -StartEarly $StartEarly -StartEarlyPhase $StartEarlyPhase -P2Singleton $P2Singleton -Verbose
             }
         else
             {
-                $SpawnedPlots = Invoke-PlotoJob -BufferSize $BufferSize -Thread $Thread -OutDriveDenom $OutDriveDenom -TempDriveDenom $TempDriveDenom -EnableBitfield $EnableBitfield -WaitTimeBetweenPlotOnSeparateDisks $WaitTimeBetweenPlotOnSeparateDisks -WaitTimeBetweenPlotOnSameDisk $WaitTimeBetweenPlotOnSameDisk -MaxParallelJobsOnAllDisks $MaxParallelJobsOnAllDisks -MaxParallelJobsOnSameDisk $MaxParallelJobsOnSameDisk -EnableAlerts $EnableAlerts -InputAmountToSpawn $InputAmountToSpawn -CountSpawnedJobs $SpawnedCountOverall -T2Denom $t2denom -WindowStyle $WindowStyle -FarmerKey $FarmerKey -PoolKey $PoolKey -MaxParallelJobsInPhase1OnSameDisk $MaxParallelJobsInPhase1OnSameDisk -MaxParallelJobsInPhase1OnAllDisks $MaxParallelJobsInPhase1OnAllDisks -StartEarly $StartEarly -StartEarlyPhase $StartEarlyPhase
+                $SpawnedPlots = Invoke-PlotoJob -BufferSize $BufferSize -Thread $Thread -OutDriveDenom $OutDriveDenom -TempDriveDenom $TempDriveDenom -EnableBitfield $EnableBitfield -WaitTimeBetweenPlotOnSeparateDisks $WaitTimeBetweenPlotOnSeparateDisks -WaitTimeBetweenPlotOnSameDisk $WaitTimeBetweenPlotOnSameDisk -MaxParallelJobsOnAllDisks $MaxParallelJobsOnAllDisks -MaxParallelJobsOnSameDisk $MaxParallelJobsOnSameDisk -EnableAlerts $EnableAlerts -InputAmountToSpawn $InputAmountToSpawn -CountSpawnedJobs $SpawnedCountOverall -T2Denom $t2denom -WindowStyle $WindowStyle -FarmerKey $FarmerKey -PoolKey $PoolKey -MaxParallelJobsInPhase1OnSameDisk $MaxParallelJobsInPhase1OnSameDisk -MaxParallelJobsInPhase1OnAllDisks $MaxParallelJobsInPhase1OnAllDisks -StartEarly $StartEarly -StartEarlyPhase $StartEarlyPhase -P2Singleton $P2Singleton
             }
         
         
@@ -1627,26 +1642,6 @@ if ($PlotsToMove)
                                     Write-Host "PlotoMover @"(Get-Date)": Moving plot: "$plot.FilePath "to" $DestinationDrive "using BITS"
                                     $source = $plot.FilePath
                                     Start-BitsTransfer -Source $source -Destination $DestinationDrive -Description "Moving Plot" -DisplayName "Moving Plot"
-                            
-                                    while ((Get-BitsTransfer | Where-Object { $_.JobState -eq "Transferring" }).Count -gt 0) {     
-                                        $totalbytes=0;    
-                                        $bytestransferred=0; 
-                                        $timeTaken = 0;    
-                                        foreach ($job in (Get-BitsTransfer | Where-Object { $_.JobState -eq "Transferring" } | Sort-Object CreationTime)) {         
-                                            $totalbytes += $job.BytesTotal;         
-                                            $bytestransferred += $job.bytestransferred     
-                                            if ($timeTaken -eq 0) { 
-                                                #Get the time of the oldest transfer aka the one that started first
-                                                $timeTaken = ((Get-Date) - $job.CreationTime).TotalMinutes 
-                                            }
-                                        }    
-                                        #TimeRemaining = (TotalFileSize - BytesDownloaded) * TimeElapsed/BytesDownloaded
-                                        if ($totalbytes -gt 0) {        
-                                            [int]$timeLeft = ($totalBytes - $bytestransferred) * ($timeTaken / $bytestransferred)
-                                            [int]$pctComplete = $(($bytestransferred*100)/$totalbytes);     
-                                            Write-Progress -Status "Transferring $bytestransferred of $totalbytes ($pctComplete%). $timeLeft minutes remaining." -Activity "Dowloading files" -PercentComplete $pctComplete  
-                                        }
-                                    }
                                 }
 
                             catch

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.0.9.4.9.2
+Version: 1.0.9.4.9.3
 Author: Tydeno
 
 
@@ -721,7 +721,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                         {
                                             #Lets check if its a Key
                                             $CharArray = $P2Singleton.ToCharArray()
-                                            if ($CharArray.Count -eq 96)
+                                            if ($CharArray.Count -gt 61)
                                                 {
                                                     Write-Verbose ("PlotoSpawner @ "+(Get-Date)+": This looks like a valid key based on its length")
                                                     $ExpandedArgs = "-c "+$P2Singleton

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -29,7 +29,7 @@
         "Thread": "4",
         "Bitfield": "true",
         "FarmerKey": "",
-        "PoolKey": ""
+        "PoolKey": "",
         "P2SingletonAdress": ""
       }
     ],

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -30,6 +30,7 @@
         "Bitfield": "true",
         "FarmerKey": "",
         "PoolKey": ""
+        "P2SingletonAdress": ""
       }
     ],
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,7 @@ For reference heres my setup:
 So my denominators for my TempDrives its "plot" and for my destination drives its "out".
 
 ### About -2 drives
-Ploto now supports -2 drives. You define them just like plot and tempdrives. On each Job Ploto checks if a -2 drive is plottable. If yes, it spawns the job using that -2 drive. If not, it spawns the job without the drive. The implementation is rather basic now, as I currently do not use -2 drives for my plotting and may not understand the usage of this param correctly yet. 
-
+Ploto now supports -2 drives. You define them just like plot and tempdrives. On each Job Ploto checks if a -2 drive is plottable. If yes, it spawns the job using that -2 drive. If not, it spawns the job without the drive. 
 
 > -2 [tmp dir 2]: Define a secondary temporary directory for plot creation. This is where Plotting Phase 3 (Compression) and Phase 4 (Checkpoints) occur. Depending on your OS, > -2 might default to either -t or -d. Therefore, if either -t or -d are running low on space, it's recommended to set -2 manually. The -2 dir requires an equal amount of > > working space as the final size of the plot.
 
@@ -204,6 +203,19 @@ Now change the WebhookUrl to match the URL of your Discord Servers Webhook and e
 Set the Name for your plotter, as it allows you to distinguish between alerts for each plotter. You may also use several Webhooks in different Discord Channels.
 
 When you Start Ploto, make sure you also specified the Parameter "EnableAlerts" in the config. If not specified, your Disocrd remains silent.
+
+## Plotting with your Pool & Farmer Key
+If your keys are not the present on the machine you want to plot, you need to specify -p (PoolKey) and -f (FarmerKey) param of your farm, in order to farm these plots correctly.
+If no -pf and -f param are specified, it uses the available keys.
+
+## Plotting for pools
+Ploto now supports pool plotting, since we know the needed commands. 
+Be advises that this in BETA mode right now.
+
+To create portable pool plots, we need to use the param "P2Singleton" in the config. 
+Therefore we need to create a singleton that points to a pool first, and then we can start plotting. 
+
+If you want to plot portable pools, make sure FarmerKey and PoolKey are NOT specified in the config, as this will mess thing up
 
 
 # Prereqs


### PR DESCRIPTION
## Added
* Ability to pass -c param to Chia plots create
Be advised, this is a beta. It is based on the demo we saw from Mariano at the pool operators call. Might not be working correctly yet. closes #78 
* Ploto now checks for NVMEs to spawn the jobs on. If an NVME is found and defined as a TempDrive, it will be used first to spawn a plot on. closes #74 

## Changed
* Added an additional check for OutDrives, if they have JobsinProgress.

## Removed
* ProgressBar for PlotoMover using Bits