### PR TITLE
change to driveletters from denom

### DIFF
--- a/Install-Ploto.ps1
+++ b/Install-Ploto.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 0.625
+Version: 0.7
 Author: Tydeno
 
 
@@ -284,33 +284,22 @@ $WindowStyle = Read-Host -Prompt "ConfigurePloto: Do you want to the plot jobs i
 Write-Host "-------------------------------------"
 
 Write-Host "ConfigurePloto: Lets go over to the disk config..."
+Write-Host "ConfigurePloto: To define your drives, use the following notation:"  
+Write-Host "ConfigurePloto: To define one drive, use the following notation: F:"
+Write-Host "ConfigurePloto: To define several drives, use the following notation: F:,E:,K:"
+Write-Host "ConfigurePloto: To define a folder within a  drive, use following notation: F:\afolder,E:\anotherone,K:\somefolder"
+$TempDrives = Read-Host -Prompt "ConfigurePloto: Define your TempDrives."
+$config.DiskConfig | % {$_.TempDrives = $TempDrives}
 
-$TempDriveDenom = Read-Host -Prompt "ConfigurePloto: Define your TempDrive Denom (eg: plot)"
-$config.DiskConfig | % {$_.TempDriveDenom = $TempDriveDenom}
-$tempdrives = Get-PlotoTempDrives -TempDriveDenom $TempDriveDenom
-Write-Host "Will be using the following Drives as TempDrives:"
-$tempdrives | ft
-
-
-$OutDriveDenom = Read-Host -Prompt "ConfigurePloto: Define your OutDrive Denom (eg: out)"
-$config.DiskConfig | % {$_.OutDriveDenom = $OutDriveDenom}
-$outdrives = Get-PlotoOutDrives -OutDriveDenom $OutDriveDenom
-
-Write-Host "Will be using the following Drives as OutDrives:"
-$outdrives | ft
-
-
+$OutDrives = Read-Host -Prompt "ConfigurePloto: Define your OutDrives"
+$config.DiskConfig | % {$_.OutDrives = $OutDrives}
 
 $EnableT2 = Read-Host -Prompt "ConfigurePloto: Do you want to enable T2 drives? (eg: Yes or No)"
-
 
 if ($EnableT2 -eq "Yes" -or $EnableT2 -eq "yes" -or $EnableT2 -eq "y")
     {
         $config.DiskConfig | % {$_.EnableT2 = "true"}
-        $t2denom = Read-Host -Prompt "ConfigurePloto: Define your t2 drivedenom (eg: t2)"
-        $t2drives = Get-PlotoT2Drives -T2Denom $t2denom
-        Write-Host "Will be using the following Drives as T2Drives:"
-        $t2drives  | ft
+        $t2denom = Read-Host -Prompt "ConfigurePloto: Define your t2drives"
 
     }
 else
@@ -319,9 +308,7 @@ else
         $t2denom = ""        
     }
 
-$config.DiskConfig | % {$_.Temp2Denom = $t2denom}
-
-
+$config.DiskConfig | % {$_.Temp2drives = $t2denom}
 
 
 $replot = Read-Host -Prompt "ConfigurePloto: Do you want to replot existing plots? (eg: Yes or No)"
@@ -329,15 +316,13 @@ if ($replot -eq "Yes" -or $replot -eq "yes" -or $replot -eq "y")
      {
         Write-Host "ConfigurePloto: Will be replotting." -ForegroundColor Magenta
         $config.SpawnerConfig | % {$_.ReplotForPool = "true"}
-        $replotDenom = Read-Host "Define your replot Denom (eg: redeploy)"
-        $config.DiskConfig | % {$_.DenomForOutDrivesToReplotForPools = $replotDenom}
-
-        
+        $replotDenom = Read-Host "Define your ReplotDrives"
+        $config.DiskConfig | % {$_.ReplotDrives = $replotDenom}
     }
 else
     {
         Write-Host "ConfigurePloto: Will not be replotting." -ForegroundColor Magenta
-        $config.DiskConfig | % {$_.DenomForOutDrivesToReplotForPools = ""}   
+        $config.DiskConfig | % {$_.ReplotDrives = ""}   
         $config.SpawnerConfig | % {$_.ReplotForPool = "false"}
     }
     
@@ -475,6 +460,20 @@ if ($consent -eq "Yes" -or $consent -eq "y")
     {
         try 
             {
+
+                $tempdrives = Get-PlotoTempDrives 
+                Write-Host "Will be using the following Drives as TempDrives:"
+                $tempdrives | ft
+
+                $outdrives = Get-PlotoOutDrives
+
+                Write-Host "Will be using the following Drives as OutDrives:"
+                $outdrives | ft
+
+                $t2drives = Get-PlotoT2Drives 
+                Write-Host "Will be using the following Drives as T2Drives:"
+                $t2drives  | ft
+
                 $destination = $env:HOMEDRIVE+$env:HOMEPath+"\.chia\mainnet\config\"
                 Copy-Item -Path $PathToConfig -Destination $destination -Force
                 Write-Host "InstallPloto @"(Get-Date)": Copied config successfully to: " $destination -ForegroundColor Green

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.1.1.6cd
+Version: 1.1.1.6
 Author: Tydeno
 
 .DESCRIPTION

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2561,7 +2561,7 @@ function Invoke-PlotoDeleteForReplot
 
 	Param(
 		[parameter(Mandatory=$true)]
-		$ReplotDriveDenom
+		$ReplotDrives
 		)
 
     #Get active jobs entering phase 4.
@@ -2574,7 +2574,7 @@ function Invoke-PlotoDeleteForReplot
                 {
                         Write-Host ("PlotoDeleteForReplot @ "+(Get-Date)+": Checking if selected ReplotDrive has enough space or oldest plot needs to be deleted..")
                         #Check if we need to delete a plot on that OutDrive spacewise, with active jobs to it in mind.
-                        $OutDriveToCheck = Get-PlotoOutDrives | Where-Object {$_.DriveLetter -eq $job.OutDrive}
+                        $OutDriveToCheck = Get-PlotoOutDrives -Replot $true | Where-Object {$_.DriveLetter -eq $job.OutDrive}
 
                         if ($OutDriveToCheck.FreeSpace -lt 107 -and $OutDriveToCheck.AvailableAmountToPlot -le 1)
                             {

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.1.4
+Version: 1.1.1
 Author: Tydeno
 
 .DESCRIPTION

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1650,7 +1650,7 @@ function Start-PlotoSpawns
     Write-Host "--------------------------------------------------------------------------------------------------"
 
     Write-Host "PlotoManager @"(Get-Date)": DiskConfig" -ForegroundColor Gray
-    Write-Host "PlotoManager @"(Get-Date)": Using temp drives: "$TempDrives-ForegroundColor Gray
+    Write-Host "PlotoManager @"(Get-Date)": Using temp drives: "$TempDrives -ForegroundColor Gray
     Write-Host "PlotoManager @"(Get-Date)": Using -2 drives: "$t2drives -ForegroundColor Gray
     Write-Host "PlotoManager @"(Get-Date)": Using destination drives: "$OutDrives -ForegroundColor Gray
     Write-Host "PlotoManager @"(Get-Date)": Common denominator for destination drives to replot (name of logical volume): "$ReplotDrives -ForegroundColor Gray

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -10,10 +10,10 @@
   "DiskConfig": [
     {
       "TempDrives": "E:\, P:\",
-      "Temp2Drives": "K:\",
+      "Temp2Drives": "K:\Potter",
       "OutDrives": "",
       "EnableT2": "false",
-      "DenomForOutDrivesToReplotForPools": ""
+      "ReplotDrives": ""
     }
   ],
 

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -9,7 +9,7 @@
 
   "DiskConfig": [
     {
-      "TempDrives": "E:\\,P:\",
+      "TempDrives": "E:\\,P:\\",
       "Temp2Drives": "K:\\Plotter",
       "OutDrives": "",
       "EnableT2": "false",

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -9,9 +9,9 @@
 
   "DiskConfig": [
     {
-      "TempDriveDenom": "",
-      "Temp2Denom": "",
-      "OutDriveDenom": "",
+      "TempDrive": "E:\, P:\",
+      "Temp2Drive": "K:\",
+      "OutDrive": "",
       "EnableT2": "false",
       "DenomForOutDrivesToReplotForPools": ""
     }

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -9,8 +9,8 @@
 
   "DiskConfig": [
     {
-      "TempDrives": "E:\, P:\",
-      "Temp2Drives": "K:\Potter",
+      "TempDrives": "E:\\,P:\",
+      "Temp2Drives": "K:\\Plotter",
       "OutDrives": "",
       "EnableT2": "false",
       "ReplotDrives": ""

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -9,9 +9,9 @@
 
   "DiskConfig": [
     {
-      "TempDrive": "E:\, P:\",
-      "Temp2Drive": "K:\",
-      "OutDrive": "",
+      "TempDrives": "E:\, P:\",
+      "Temp2Drives": "K:\",
+      "OutDrives": "",
       "EnableT2": "false",
       "DenomForOutDrivesToReplotForPools": ""
     }

--- a/README.md
+++ b/README.md
@@ -71,62 +71,8 @@ On top of that; it always makes sense to set your reward address to a cold walle
 
 # PlotoSpawn
 TLDR: It plots 1x plot on each TempDrive (if you have 6x TempDrives = 6x parallel Plot Jobs) as long as you want it to and as long as you have OutDrive space.
-When and where Plots are spawned is defined by PlotoSpawnerConfig.json which looks like this:
+When and where Plots are spawned is defined by PlotoSpawnerConfig.json.
 
-```
-{
-    "PlotterName": "SirNotPlotAlot",    | The Name of your plotter
-    "EnableAlerts": "false",            | Enable JobSpawned Alerts (Webhook config in PlotoAlertsConfig.json)
-    "ChiaWindowStyle": "hidden",        | Determines Window Style of chia.exe (Allowed Values: normal, hidden, maximized, minimized)
-    "PathToPloto": "C:/Users/Tydeno/Desktop/Ploto/Ploto.psm1", | Absolute path to the module as the background jobs needs to load it again
-
-    "DiskConfig": [
-      {
-        "TempDriveDenom": "plot",      | The common denominator for all your TempDrives
-	"Temp2Denom": "t2",	       | The common denominator for all your Temp2Drives
-        "OutDriveDenom": "out",        | The common denominator for all your OutDrives
-	"EnableT2": "true",            | Determines if Ploto uses Temp2 drives. Must be set to true along with temp2denom defined
-	"DenomForOutDrivesToReplotForPools": "replot" | The common denominator for all your Drives with final plots you want to replot
-      }
-    ],
-
-    "JobConfig": [
-        {
-	  "KSizeToPlot": "32",
-          "ReplotForPool": "true",                    | If enabled, ReplotWatchDog will be started and all Jobs will use the drives defined by replotdrivedenom as OutDrives
-	  "IntervallToCheckInMinutes": "5",   	      | Defines the time Ploto waits between each iteration to check for available tempd drives again 
-    	  "InputAmountToSpawn": "100",                | Amount of jobs maximal to be spawned in this launch of ploto
-          "WaitTimeBetweenPlotOnSeparateDisks": "15", | Wait time in minutes Ploto waits until a new job on another disk is spawned
-          "WaitTimeBetweenPlotOnSameDisk": "30",      | Wait time in minutes Ploto waits until a new job on the same disk is spawned
-          "MaxParallelJobsOnAllDisks": "6", 	      | Maximum amount of parallel jobs allowed on all disks combined
-          "MaxParallelJobsOnSameDisk": "2", 	      | Maximum amount of parallel jobs allowed on a single disk. Affects all disks of all sizes. Set to you're highest disk.
-	  "MaxParallelJobsInPhase1OnSameDisk": "2",   | Maximum amoumt of parallel jobs allowed on the same in  phase 1
-          "MaxParallelJobsInPhase1OnAllDisks" : "10", | Maximum amoumt of parallel jobs allowed on all disks in  phase 1
-          "StartEarly": "true",		              | Enable EarlyStart (when jobs completed StatusEarlyPhase)
-          "StartEarlyPhase": "3",                     | Defines when a job should be early started. If a job completes phase 3 in this example, it is not considered an active                                                           job anymore and makes room for another to spawn early.
-          "BufferSize": "1000",
-          "Thread": "1",
-          "Bitfield": "true",
-	  "P2SingletonAdress": "sisda78sd78sdauzida789hjsa7sa78saiou" | Your P2Singletonadress used to create portable plot. Do not specify together with -p and -f!
-        }
-      ]
-    "SpawnerAlerts": [
-	    {
-	      "DiscordWebhookURL": "https://discord.com/api/webhooks/xxxxxxxxxxxxxxxx",    | EndpointURL of your discord Webhook 
-	      "WhenJobSpawned": "true",                                                
-	      "WhenNoOutDrivesAvailable": "true",
-	      "WhenJobCouldNotBeSpawned": "true"
-	    }
-	  ],
-
-	  "PlotoFyAlerts": [
-	    {
-	      "DiscordWebhookURL": "https://discord.com/api/webhooks/xxxxxxxxxxxxxx",    | EndpointURL of your discord Webhook 
-	      "PeriodOfReportInHours": "1",                                              | Period the report is send out and covering    
-	    }
-	  ]
-}
-```
 Ploto checks periodically, if a TempDrive and OutDrive is available for plotting. 
 If there is no TempDrive available, or no OutDrive, Ploto checks again in amount of minutes defines in $config.IntervallToCheckInMinutes
 
@@ -135,34 +81,13 @@ Ploto iterates once through all available TempDrives and spawns a plot per each 
 After that, Ploto checks if amount Spawned is equal as defined as input. If not, Ploto keeps going until it is.
 
 ### Understanding Plot and OutDrives
-PlotoSpawner identifies your drives for temping and storing plots by a common denominator you specify. 
-This means that all drives that match that denominator, will be used as either Temp or OutDrive.
+To define your temp and outdrives you use the config.
+To define a folder within a drive, use following notation: 
+`F:\\afolder,E:\\anotherone,K:\\somefolder`
 
-IMPORTANT: Ploto Assumes you Plot in the root of your Drives and that the Drives are dedicated to plotting. So make sure you do that aswell.
-It may work when the drives contains other data but, but Ploto was designed for empty, plot-only drives.
-EDIT: I noticed I have a folder in my Q:\ drive with some data. So it seems to work. 
+to define several drivesuse :`F:,E:,K:`
 
-For reference heres my setup:
-* CPU: i9-9900k
-* RAM: 32 GB DDR4
-* TempDrives:
-
-| Name          | DriveLetter | Type   | Size      |
-|---------------|----------|--------|--------------|
-|ChiaPlot 1 | I:\ | SATA SSD | 465 GB
-|ChiaPlot 2 | H:\ | SATA SSD | 465 GB
-|ChiaPlot 3 | E:\ | SATA SSD | 465 GB
-|ChiaPlot 4 | Q:\ | SATA SSD | 1810 GB
-|ChiaPlot 5 | J:\ | NVME SSD PCI 16x | 465 GB
-
-* OutDrives:
-
-| Name          | DriveLetter | Type   | Size      |
-|---------------|----------|--------|--------------|
-|ChiaOut 1 | K:\ | SATA HDD | 465 GB
-|ChiaOut 2 | D:\ | SATA HDD | 465 GB
-
-So my denominators for my TempDrives its "plot" and for my destination drives its "out".
+Important: There are no spaces allowed betwen the ","!
 
 ### About -2 drives
 Ploto now supports -2 drives. You define them just like plot and tempdrives. On each Job Ploto checks if a -2 drive is plottable. If yes, it spawns the job using that -2 drive. If not, it spawns the job without the drive. 


### PR DESCRIPTION
# Added
* Support for Ramdisks closes #88 

# Changed
* Now using Driveletters and or UNC paths instead of a denominator to specify your drives closes #94 


Sample disk config:
``` 
   "DiskConfig":  [
                       {
                           "TempDrives":  "B:,D:,E:",
                           "Temp2Drives":  "A:,Y:,Z:",
                           "OutDrives":  "H:\\Plots,K:\\Archiv,I:,P:,Q:,R:,S:,T:,X:",
                           "EnableT2":  "true",
                           "ReplotDrives":  ""
                       }
                   ],
```