### PR TITLE
mover in cfg and replot enhancements

### DIFF
--- a/Install-Ploto.ps1
+++ b/Install-Ploto.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 0.84
+Version: 0.841
 Author: Tydeno
 
 
@@ -141,7 +141,6 @@ function Get-JsonDifference
     }
 
 }
-
 
 function Get-JsonDifferenceRecursion
 {
@@ -535,6 +534,7 @@ If (Test-Path $DestinationContainer)
                         Write-Host "InstallPloto @"(Get-Date)": We skipped updating. Using currently installed version of Ploto:"$PlotoVersionInSource -ForegroundColor Yellow
                     }
             }
+
     }
 else
     {

--- a/Install-Ploto.ps1
+++ b/Install-Ploto.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 0.82
+Version: 0.84
 Author: Tydeno
 
 
@@ -642,7 +642,6 @@ if (Test-Path $pathtolchech)
         if ($checkAdded -match "@")
             {
                 Write-Host "InstallPloto @"(Get-Date)": New properties were introduced in new version, need to update config!" -ForegroundColor Yellow
-                Write-Host "InstallPloto @"(Get-Date)": New properties:" -ForegroundColor Yellow
                 Write-Host "InstallPloto @"(Get-Date)": Added: "$compare.added -ForegroundColor Yellow
                 
             }

--- a/Install-Ploto.ps1
+++ b/Install-Ploto.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 0.8
+Version: 0.82
 Author: Tydeno
 
 
@@ -738,6 +738,19 @@ else
     {
         $config | % {$_.EnableAlerts = "false"}
         $config | % {$_.EnablePlotoFyOnStart = "false"}
+    }
+
+$EnableMover = Read-Host "ConfigurePloto: Do you want to enable PlotoMover (moves final plots to defined path)? (eg: Yes or No)"
+if ($EnableMover -eq "y" -or $EnableMover -eq "Yes")
+    {
+        $PathsToMoveTo = Read-Host "Configure Ploto: Define the paths you want to move final plots to:"
+        $config | % {$_.EnableMover = "true"}
+        $config | % {$_.PathsToMovePlotsTo = $PathsToMoveTo}
+    }
+else
+    {
+         $config | % {$_.EnableMover = "false"}
+         $config | % {$_.PathsToMovePlotsTo = ""}
     }
 
 $WindowStyle = Read-Host -Prompt "ConfigurePloto: Do you want to the plot jobs in background? (eg: Yes or No)"

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.2399997
+Version: 1.1.2399998
 Author: Tydeno
 
 .DESCRIPTION
@@ -2736,7 +2736,7 @@ if ($PlotsToMove)
                             foreach ($trans in $AllBits)
                                 {
                                     #getFileName and DrLetter
-                                    $DestDriveInJob = $trans.FileList.LocalName.split("\")[0]
+                                    $DestDriveInJob = $trans.FileList.RemoteName.split("\")[0]
 
                                     $JobtoPass = [PSCustomObject]@{
                                     DriveLetter     =  $DestDriveInJob

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.231
+Version: 1.1.232
 Author: Tydeno
 
 .DESCRIPTION
@@ -2623,9 +2623,10 @@ function Start-PlotoMove
             Throw $_.Exception.Message
         } 
 
-    $PathToModule = $config.PathToPloto
-    Unblock-File $PathToModule
-    Request-PlotoMove 
+    $PathToPloto = $config.PathToPloto 
+    Unblock-File $PathToPloto
+    Import-Module $PathToPloto -Force
+    Request-PlotoMove
 
     } -Name "PlotoMove" 
 }

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.1.3
+Version: 1.1.31
 Author: Tydeno
 
 .DESCRIPTION
@@ -1042,6 +1042,14 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                 if ($EnableAlerts -eq $true -and $config.SpawnerAlerts.WhenJobSpawned -eq "true")
                                                     {
                                                         Write-Host "PlotoSpawner @"(Get-Date)": Event notification in config defined. Sending Discord Notification about spawned job..."
+                                                        $countchars = ($ArgumentList.ToCharArray()).Count
+                                                        if ($countchars -gt 199)
+                                                            {
+                                                                $ArgumentList = $ArgumentList -replace ".{199}$"
+                                                                $exArgs = "-f YourKeys -p YourKeys"
+                                                                $ArgumentListReport = $ArgumentList+$exArgs
+                                                            }
+
 
                                                         try 
                                                             {
@@ -1097,7 +1105,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                                 $embedBuilder.AddField(
                                                                     [DiscordField]::New(
                                                                         'ArgumentList',
-                                                                        $ArgumentList, 
+                                                                        $ArgumentListReport, 
                                                                         $true
                                                                     )
                                                                 )
@@ -2093,6 +2101,7 @@ foreach ($log in $logs)
                 {
                     $IsReplot = "false"
                 }
+
             $countchars = ($ArgumentList.ToCharArray()).Count
             if ($countchars -gt 199)
                 {
@@ -2100,8 +2109,6 @@ foreach ($log in $logs)
                     $exArgs = "-f YourKeys -p YourKeys"
                     $ArgumentList = $ArgumentList+$exArgs
                 }
-
-
 
             if ($PerfCounter)
                 {
@@ -2878,7 +2885,18 @@ function Invoke-PlotoFyStatusReport
                 {   
                     $countji++
                     $ArgId = "ArgumentList Job "+$countji
-                    $JobDetailsArgListMsg = $ji.ArgumentList.TrimStart("plots create ")
+                    $ArgumentList = $ji.ArgumentList
+
+                    $countchars = ($ArgumentList.ToCharArray()).Count
+                    if ($countchars -gt 199)
+                        {
+                            $ArgumentList = $ArgumentList -replace ".{199}$"
+                            $exArgs = "-f YourKeys -p YourKeys"
+                            $ArgumentListReport = $ArgumentList+$exArgs
+                        }
+
+
+                    $JobDetailsArgListMsg = $ArgumentListReport
                     $embedBuilder.AddField(
                         [DiscordField]::New(
                             $ArgId,

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.23999
+Version: 1.1.239991
 Author: Tydeno
 
 .DESCRIPTION
@@ -2838,7 +2838,7 @@ function Invoke-PlotoDeleteForReplot
 		)
 
     #Get active jobs entering phase 4.
-    $activeJobs = Get-PlotoJobs | Where-Object {$_.Status -ge 3.9} | Where-Object {$_.IsReplot -eq "true"} | Where-Object {$_.Status -ne "Completed"}
+    $activeJobs = Get-PlotoJobs | Where-Object {$_.Status -ge 3.9} | Where-Object {$_.IsReplot -eq "true"} | Where-Object {$_.Status -ne "Completed"} | Where-Object {$_.Status -ne "Aborted"}
     if ($activeJobs)
         {
             Write-Host ("PlotoDeleteForReplot @ "+(Get-Date)+": Found active jobs that are about to enter phase 4")

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1642,7 +1642,7 @@ function Start-PlotoSpawns
 
     Write-Host "--------------------------------------------------------------------------------------------------"
 
-    Write-Host "PlotoManager @"(Get-Date)": BaseConfig:" -ForegroundColor Cyan
+    Write-Host "PlotoManager @"(Get-Date)": BaseConfig" -ForegroundColor Cyan
 
     Write-Host "PlotoManager @"(Get-Date)": Alerts Enabled:"$EnableAlerts -ForegroundColor Cyan
     Write-Host "PlotoManager @"(Get-Date)": DiscordWebhookURL:"$DiscoUrl -ForegroundColor Cyan
@@ -1651,7 +1651,7 @@ function Start-PlotoSpawns
     Write-Host "PlotoManager @"(Get-Date)": Using Plotter:"$Plotter -ForegroundColor Cyan
     Write-Host "PlotoManager @"(Get-Date)": Custom plotter path"$PathToUnofficialPlotter -ForegroundColor Cyan
     Write-Host "PlotoManager @"(Get-Date)": PlotoMover is enabled:"$EnableMover -ForegroundColor Cyan
-    Write-Host "PlotoManager @"(Get-Date)": Paths to move final Plots to"$PathsToMovePlotsTo-ForegroundColor Cyan
+    Write-Host "PlotoManager @"(Get-Date)": Paths to move final Plots to"$PathsToMovePlotsTo -ForegroundColor Cyan
 
     Write-Host "--------------------------------------------------------------------------------------------------"
 
@@ -1672,7 +1672,7 @@ function Start-PlotoSpawns
     Write-Host "PlotoManager @"(Get-Date)": Using temp drives: "$TempDrives -ForegroundColor Gray
     Write-Host "PlotoManager @"(Get-Date)": Using -2 drives: "$t2drives -ForegroundColor Gray
     Write-Host "PlotoManager @"(Get-Date)": Using destination drives: "$OutDrives -ForegroundColor Gray
-    Write-Host "PlotoManager @"(Get-Date)": Common denominator for destination drives to replot (name of logical volume): "$ReplotDrives -ForegroundColor Gray
+    Write-Host "PlotoManager @"(Get-Date)": Will be replotting the following drives: "$ReplotDrives -ForegroundColor Gray
 
     Write-Host "--------------------------------------------------------------------------------------------------"
 

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239999996
+Version: 1.1.239999998
 Author: Tydeno
 
 .DESCRIPTION

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.22
+Version: 1.1.23
 Author: Tydeno
 
 .DESCRIPTION
@@ -55,7 +55,7 @@ $collectionWithDisks= New-Object System.Collections.ArrayList
 foreach ($drive in $outdrivescfg)
     {
 
-            if ($drive.contains("\"))
+        if ($drive.contains("\"))
             {
                 $drletter = $drive.Split("\")[0]
                 $FullPathToUse = $drive
@@ -2412,12 +2412,7 @@ if ($replot)
         $OutDrivesToScan = Get-PlotoOutDrives -Replot $true
     }
 
-if ($mover)
-    {
-        $OutDrivesToScan = Get-PlotoOutDrives -Mover $true
-    }
-
-if ($replot -eq $null -and $mover -eq $null)
+if ($replot -eq $null)
     {
         $OutDrivesToScan = Get-PlotoOutDrives
     }

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.233
+Version: 1.1.234
 Author: Tydeno
 
 .DESCRIPTION
@@ -3080,7 +3080,7 @@ $ReplotDriveDenom = $config.DiskConfig.ReplotDrives
 $count = 0
     for ($count -lt 100000000000)
         {
-           Invoke-PlotoDeleteForReplot -ReplotDriveDenom $ReplotDriveDenom
+           Invoke-PlotoDeleteForReplot -ReplotDrives $ReplotDriveDenom
            $count++
            Start-Sleep 300 
         }

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.1.28911
+Version: 1.1.28912
 Author: Tydeno
 
 .DESCRIPTION
@@ -142,7 +142,6 @@ foreach ($drive in $outdrivescfg)
                                 $AmountOfPlotsToTempMax = $AvailableAmounToPlot + $PlotInProgressCount
                             }
                     }
-                    Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 142?" -ForegroundColor Magenta  
                 else
                     {
                         $HasPlotInProgress = $false

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.2399992
+Version: 1.1.2399993
 Author: Tydeno
 
 .DESCRIPTION
@@ -2680,7 +2680,7 @@ function Move-PlotoPlots
         } 
  
 $DestinationDrives = Get-PlotoOutDrives -Mover $true
-$PlotsToMove = Get-PlotoPlots
+$PlotsToMove = Get-PlotoPlots -mover $true
 
 
 foreach ($plot in $PlotsToMove)

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239994
+Version: 1.1.239995
 Author: Tydeno
 
 .DESCRIPTION
@@ -1419,7 +1419,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                                     #Create embed builder object via the [DiscordEmbed] class
                                                                     $embedBuilder = [DiscordEmbed]::New(
                                                                                         'New Job Spawned',
-                                                                                        'Hei its Ploto here. I spawned a new plot job for you.'
+                                                                                        'Hei its Ploto here. I spawned a new plot job for you. I used Stotiks plotter.'
                                                                                     )
 
                                                                     #Create the field and then add it to the embed. The last value ($true) is if you want it to be in-line or not

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239999998
+Version: 1.1.2
 Author: Tydeno
 
 .DESCRIPTION

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2710,7 +2710,7 @@ $crtime = Get-Date -Day ($crtime.Split(".")[0]) -Month ($crtime.Split(".")[1]) -
 
 if ($replot -eq "true")
     {
-        $PlotsToMove = Get-PlotoPlots -mover $true | where-object {$_.CreationTime -lt $crtime}
+        $PlotsToMove = Get-PlotoPlots -mover $true | where-object {$_.CreationTime -gt $crtime}
     }
 
 else

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239991
+Version: 1.1.239992
 Author: Tydeno
 
 .DESCRIPTION
@@ -777,7 +777,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                             $min = ($replotDrives | measure-object -Property FreeSpace -minimum).minimum
                                             $OutDrive = $replotDrives | Where-Object { $_.FreeSpace -eq $min}
 
-                                            $FinalPlots = Get-PlotoPlots -replot $true
+                                            $FinalPlots = Get-PlotoPlots -replot $true | out-null
                                             $collectionWithPlots= New-Object System.Collections.ArrayList
                                             if ($FinalPlots)
                                                 {
@@ -826,6 +826,9 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                             else
                                                 {
                                                     Write-Host ("PlotoSpawner @ "+(Get-Date)+": No final plots have been found. ")
+                                                    Write-Host "There is no OutDrive that has plots older than specified. Selecting OutDrive with space. Using the Outdrive with most free space for plotting."
+                                                    $max = ($replotDrives | measure-object -Property FreeSpace -maximum).maximum
+                                                    $OutDrive = $replotDrives | Where-Object { $_.FreeSpace -eq $max}
                                                 }
  
                                         }

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.2399996
+Version: 1.1.2399997
 Author: Tydeno
 
 .DESCRIPTION
@@ -2702,7 +2702,7 @@ foreach ($plot in $PlotsToMove)
                 }
     }
 
-$PlotsToMove = Get-PlotoPlots
+$PlotsToMove = Get-PlotoPlots -mover $true
 Write-Host "PlotoMover @"(Get-Date)": Checking if we have any plots to move..." 
 
 if ($PlotsToMove)

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239999994
+Version: 1.1.239999995
 Author: Tydeno
 
 .DESCRIPTION
@@ -2575,7 +2575,7 @@ if ($OutDrivesToScan)
                         {
                             If ($item.Extension -eq ".PLOT" -and $item.CreationTime -le $datetoComp)
                                 {
-                                    Write-Host ("GetPlotoPlots @ "+(Get-Date)+": Found a Final plot that is older than specified date: "+$item.fullname)
+                                    Write-Verbose ("GetPlotoPlots @ "+(Get-Date)+": Found a Final plot that is older than specified date: "+$item.fullname)
                                     $FilePath = $item.Directory.Name + $item.name
                                     $Size = [math]::Round($item.Length  / 1073741824, 2)
 
@@ -2590,7 +2590,7 @@ if ($OutDrivesToScan)
                                 }
                             else
                                 {
-                                    Write-Host ("GetPlotoPlotsReplot @ "+(Get-Date)+": This is no plot that is older than specified date: "+$item.fullname) -ForegroundColor Yellow
+                                    Write-Verbose ("GetPlotoPlotsReplot @ "+(Get-Date)+": This is no plot that is older than specified date: "+$item.fullname) 
                                 }
                         }
                     if ($mover)
@@ -2598,7 +2598,7 @@ if ($OutDrivesToScan)
                         
                             If ($item.Extension -eq ".PLOT")
                                 {
-                                    Write-Host -ForegroundColor Green "Found a Final plot to move: "$item
+                                    Write-Verbose ("Found a Final plot to move: "+$item.fullname)
                     
                                     $FilePath = $item.Directory.Name + $item.name
                                     $Size = [math]::Round($item.Length  / 1073741824, 2)
@@ -2614,7 +2614,7 @@ if ($OutDrivesToScan)
                                 }
                             else
                                 {
-                                    Write-Host "This is no plot: "$item -ForegroundColor Yellow
+                                    Write-Verbose ("This is no plot: "+$item) 
                                 }                        
                         }
                 }
@@ -2703,7 +2703,22 @@ foreach ($plot in $PlotsToMove)
                 }
     }
 
-$PlotsToMove = Get-PlotoPlots -mover $true
+
+$replot = $config.SpawnerConfig.ReplotForPool
+$crtime = $config.SpawnerConfig.ReplotPlotsOlderThan
+$crtime = Get-Date -Day ($crtime.Split(".")[0]) -Month ($crtime.Split(".")[1]) -Year ($crtime.Split(".")[2])
+
+if ($replot -eq "true")
+    {
+        $PlotsToMove = Get-PlotoPlots -mover $true | where-object {$_.CreationTime -lt $crtime}
+    }
+
+else
+    {
+        $PlotsToMove = Get-PlotoPlots -mover $true   
+    }
+
+
 Write-Host "PlotoMover @"(Get-Date)": Checking if we have any plots to move..." 
 
 if ($PlotsToMove)

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.23993
+Version: 1.1.23994
 Author: Tydeno
 
 .DESCRIPTION
@@ -2741,7 +2741,7 @@ function Invoke-PlotoDeleteForReplot
 		)
 
     #Get active jobs entering phase 4.
-    $activeJobs = Get-PlotoJobs | Where-Object {$_.Status -ge 3.9} | Where-Object {$_.IsReplot -eq "true"}
+    $activeJobs = Get-PlotoJobs | Where-Object {$_.Status -ge 3.9} | Where-Object {$_.IsReplot -eq "true"} | Where-Object {$_.Status -ne "Completed"}
     if ($activeJobs)
         {
             Write-Host ("PlotoDeleteForReplot @ "+(Get-Date)+": Found active jobs that are about to enter phase 4")

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.21
+Version: 1.1.22
 Author: Tydeno
 
 .DESCRIPTION
@@ -2618,13 +2618,20 @@ function Start-PlotoMove
     Start-Job -ScriptBlock {
     try 
         {
-            Request-PlotoMove
+            $PathToAlarmConfig = $env:HOMEDRIVE+$env:HOMEPath+"\.chia\mainnet\config\PlotoSpawnerConfig.json"
+            $config = Get-Content -raw -Path $PathToAlarmConfig | ConvertFrom-Json -ErrorAction Stop
+            Write-Verbose "Loaded Config successfully"
+            
         }
      catch
         {
             Throw $_.Exception.Message
         } 
- 
+
+    $PathToModule = $config.PathToPloto
+    Unblock-File $PathToModule
+    Request-PlotoMove 
+
     } -Name "PlotoMove" 
 }
 

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Name: Ploto
-Version: 1.1.27
+Version: 1.1.28911
 Author: Tydeno
 
 .DESCRIPTION
@@ -16,7 +16,7 @@ function Get-PlotoOutDrives
         $Mover
 		)
 
-
+Write-Host "GetPlotoOutDrives @"(Get-Date)": I've been called" -ForegroundColor Magenta  
 $PathToAlarmConfig = $env:HOMEDRIVE+$env:HOMEPath+"\.chia\mainnet\config\PlotoSpawnerConfig.json"
 
 try 
@@ -49,20 +49,23 @@ catch
          exit
     } 
 
-
+Write-Host "GetPlotoOutDrives @"(Get-Date)": cfg is there" -ForegroundColor Magenta  
 
 #Check Space for outDrives
 $collectionWithDisks= New-Object System.Collections.ArrayList
 foreach ($drive in $outdrivescfg)
     {
+        Write-Host "GetPlotoOutDrives @"(Get-Date)": looping loui" -ForegroundColor Magenta  
 
             if ($drive.contains("\"))
             {
+                Write-Host "GetPlotoOutDrives @"(Get-Date)": drive contains some '\' splitting hard. Means there is FolderDefined" -ForegroundColor Magenta  
                 $drletter = $drive.Split("\")[0]
                 $FullPathToUse = $drive
             }
         else
             {
+                Write-Host "GetPlotoOutDrives @"(Get-Date)": No folder defined" -ForegroundColor Magenta  
                 $drletter = $drive
                 $FullPathToUse = ""
             }
@@ -106,16 +109,20 @@ foreach ($drive in $outdrivescfg)
                         $DiskBus = $PhysicalDisk.BusType
                     }
 
-
+                    Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 112ish?" -ForegroundColor Magenta  
                         #Get-CurrenJobs
                 $activeJobs = Get-PlotoJobs | Where-Object {$_.OutDrive -eq $drive.DeviceId} | Where-Object {$_.Status -ne "Completed"}
+                                    Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 115?" -ForegroundColor Magenta  
                 if ($activeJobs)
                     {
                         $HasPlotInProgress = $true
+                                               Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 118?" -ForegroundColor Magenta  
                         $PlotInProgressName = $activeJobs.PlotId
+                                            Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 120?" -ForegroundColor Magenta  
                         $PlotInProgressCount = $activeJobs.count
                         $PlotInProgressPhase = $activeJobs.Status
 
+                        Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 124?" -ForegroundColor Magenta  
                         if ($PlotInProgressCount -eq $null)
                             {
                                 $PlotInProgressCount = 1
@@ -135,7 +142,7 @@ foreach ($drive in $outdrivescfg)
                                 $AmountOfPlotsToTempMax = $AvailableAmounToPlot + $PlotInProgressCount
                             }
                     }
-
+                    Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 142?" -ForegroundColor Magenta  
                 else
                     {
                         $HasPlotInProgress = $false
@@ -154,7 +161,7 @@ foreach ($drive in $outdrivescfg)
                     {
                         $IsPlottable = $false
                     }
-
+                                        Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 160?" -ForegroundColor Magenta  
 
                 If ($FreeSpace -gt 107 -and $AvailableAmounToPlot -ge 1)
                     {
@@ -165,6 +172,7 @@ foreach ($drive in $outdrivescfg)
                         $PlotToDest = $false
                     }
 
+                                    Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 170?" -ForegroundColor Magenta  
                 $outdriveToPass = [PSCustomObject]@{
                 DriveLetter     =  $drive.DeviceID
                 FullPathToUse = $FullPathToUse
@@ -181,7 +189,7 @@ foreach ($drive in $outdrivescfg)
                 PlotInProgressID = $PlotInProgressName
                 PlotInProgressPhase = $PlotInProgressPhase
                 }
-
+                Write-Host "GetPlotoOutDrives @"(Get-Date)": We go here 188?" -ForegroundColor Magenta  
                 $collectionWithDisks.Add($outdriveToPass) | Out-Null   
             }
         else
@@ -1519,11 +1527,8 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                             Write-Verbose ("PlotoSpawner @ "+(Get-Date)+": Amount of Plots in Progress overall: "+$JobCountAll)                    
                             Write-Verbose ("PlotoSpawner @ "+(Get-Date)+": Amount of Plots in Progress on this Drive: "+$JobCountOnSameDisk) 
                             Write-Verbose ("PlotoSpawner @ "+(Get-Date)+": Skipping Drive: "+$PlottableTempDrive)
-                    }                             
-
-                
-                         
-    }
+                    }                                           
+            }
     }    
 else
     {
@@ -1700,6 +1705,7 @@ function Start-PlotoSpawns
             catch
                 {
                     Write-Host "PlotoManager @"(Get-Date)": Could not launch PlotoFy!" -ForegroundColor Red
+                    Write-Host $_.Exception.Message -ForegroundColor red
                 }
 
            Write-Host "---------------------------------------------------------------------------------"
@@ -1724,6 +1730,7 @@ function Start-PlotoSpawns
             catch
                 {
                     Write-Host "PlotoManager @"(Get-Date)": Could not launch ReplotWatchDog!" -ForegroundColor Red
+                    Write-Host $_.Exception.Message -ForegroundColor red
                 }
 
            Write-Host "---------------------------------------------------------------------------------"
@@ -1748,6 +1755,7 @@ function Start-PlotoSpawns
             catch
                 {
                     Write-Host "PlotoManager @"(Get-Date)": Could not launch MoveWatchDog!" -ForegroundColor Red
+                    Write-Host $_.Exception.Message -ForegroundColor red
                 }
 
            Write-Host "---------------------------------------------------------------------------------"
@@ -2324,29 +2332,13 @@ function Remove-AbortedPlotoJobs
     $collectionWithJobsToReport= New-Object System.Collections.ArrayList
     foreach ($job in $JobsToAbort)
         {
-            if ($job.CompletionTime -eq "None")
-                {
-                    $completiontime = 0
-                }
-            else
-                {
-                    $completiontime = $job.CompletionTime
-                }
-            [datetime]$StartTime = Get-Date ($job.starttime)
-
             $JobToReport = [PSCustomObject]@{
             JobId     =  $job.jobid
-            StartTime = $job.Starttime
+            StartTime = $job.StartTime
             PlotId = $job.PlotId
             ArgumentList = $job.ArgumentList
             TempDrive = $job.TempDrive
             OutDrive = $job.OutDrive
-            CompletionTime = $job.CompletionTime
-            CompletionTimeP1 = $job.CompletionTimeP1
-            CompletionTimeP2 = $job.CompletionTimeP2
-            CompletionTimeP3 = $job.CompletionTimeP3
-            CompletionTimeP4 = $job.CompletionTimeP4
-            EndDate = (Get-Date $StartTime).AddHours($completiontime)
             }
 
             #Send notification about spotted Job that is aborted
@@ -2529,13 +2521,16 @@ function Move-PlotoPlots
             throw "Exiting cause there is no readable config."
         } 
 
-$TransferMethod = "BITS"
+Write-Host "PlotoMover @"(Get-Date)": Getting OutDrives and Plots to move..." -ForegroundColor Magenta  
 $DestinationDrives = Get-PlotoOutDrives -Mover $true
+Write-Host "PlotoMover @"(Get-Date)": Destination Drives:"$DestinationDrives 
 $PlotsToMove = Get-PlotoPlots
+
+Write-Host "PlotoMover @"(Get-Date)": Checking if we have any plots to move..." 
 
 if ($PlotsToMove)
     {
-        Write-Host "PlotoMover @"(Get-Date)": There are Plots found to be moved: "
+        Write-Host "PlotoMover @"(Get-Date)": There were Plots found to be moved: "
         foreach ($plot in $PlotsToMove)
             {
                 Write-Host $plot.filepath -ForegroundColor Green
@@ -2634,7 +2629,7 @@ function Start-PlotoMove
             Throw $_.Exception.Message
         } 
  
-    } -Name 
+    } -Name "PlotoMove" 
 }
 
 function Request-PlotoMove
@@ -2642,6 +2637,7 @@ function Request-PlotoMove
 $count = 0
     for ($count -lt 100000000000)
         {
+           Write-Host "RequestPlotoMove @"(Get-Date)": Calling Move-PlotoPlots..."
            Move-PlotoPlots
            $count++
            Start-Sleep 300 

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.234
+Version: 1.1.236
 Author: Tydeno
 
 .DESCRIPTION
@@ -2567,8 +2567,12 @@ if ($PlotsToMove)
                         {
                             if ($DestinationDrives.count -gt 1)
                                 {
-                                    $dToPick = Get-Random -Maximum (($DestinationDrives).count-1)
-                                    $DestDrive = $DestinationDrives[$dToPick]
+
+                                   #Get the FinalDir with most free space (availableamountofplotstohold)
+                                    $max = ($DestinationDrives | Measure-Object -Property AvailableAmountToPlot -Maximum).maximum
+                                    write-host "max is:"$max
+                                    $DestDrive = Get-PlotoOutDrives -Mover $true | Where-Object {$_.AvailableAmountToPlot -eq $max}
+
                                 }
                             else
                                 {
@@ -2586,12 +2590,18 @@ if ($PlotsToMove)
                             $DestDrive = $DestDrive.DriveLetter
                         }
 
+                    if ($DestinationDrive -eq $null)
+                        {
+                            Write-Host "PlotoMover @"(Get-Date)": ERROR: No Outdrives found!" -ForegroundColor Red
+                            break
+                        }
+
                     try 
-                    {
-                        Write-Host "PlotoMover @"(Get-Date)": Moving plot: "$plot.FilePath "to" $DestDrive "using BITS"
-                        $source = $plot.FilePath
-                        Start-BitsTransfer -Source $source -Destination $DestDrive -Description "Moving Plot" -DisplayName "Moving Plot"
-                    }
+                        {
+                            Write-Host "PlotoMover @"(Get-Date)": Moving plot: "$plot.FilePath "to" $DestDrive "using BITS"
+                            $source = $plot.FilePath
+                            Start-BitsTransfer -Source $source -Destination $DestDrive -Description "Moving Plot" -DisplayName "Moving Plot"
+                        }
 
                     catch
                         {

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239999995
+Version: 1.1.239999996
 Author: Tydeno
 
 .DESCRIPTION
@@ -3384,7 +3384,7 @@ $count = 0
         {
            Invoke-PlotoDeleteForReplot -ReplotDrives $ReplotDriveDenom
            $count++
-           Start-Sleep 300 
+           Start-Sleep 60
         }
 
 }

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239992
+Version: 1.1.239993
 Author: Tydeno
 
 .DESCRIPTION
@@ -777,7 +777,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                             $min = ($replotDrives | measure-object -Property FreeSpace -minimum).minimum
                                             $OutDrive = $replotDrives | Where-Object { $_.FreeSpace -eq $min}
 
-                                            $FinalPlots = Get-PlotoPlots -replot $true | out-null
+                                            $FinalPlots = Get-PlotoPlots -replot $true 
                                             $collectionWithPlots= New-Object System.Collections.ArrayList
                                             if ($FinalPlots)
                                                 {

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.239993
+Version: 1.1.239994
 Author: Tydeno
 
 .DESCRIPTION
@@ -1405,6 +1405,14 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                     if ($EnableAlerts -eq $true -and $config.SpawnerAlerts.WhenJobSpawned -eq "true")
                                                         {
                                                             Write-Host "PlotoSpawner @"(Get-Date)": Event notification in config defined. Sending Discord Notification about spawned job..."
+                                                            $countchars = ($ArgumentList.ToCharArray()).Count
+                                                            if ($countchars -gt 199)
+                                                                {
+                                                                    $ArgumentList = $ArgumentList -replace ".{199}$"
+                                                                    $exArgs = "-f YourKeys -p YourKeys"
+                                                                    $ArgumentListReport = $ArgumentList+$exArgs
+                                                                }
+
 
                                                             try 
                                                                 {
@@ -1460,7 +1468,7 @@ if ($PlottableTempDrives -and $JobCountAll0 -lt $MaxParallelJobsOnAllDisks)
                                                                     $embedBuilder.AddField(
                                                                         [DiscordField]::New(
                                                                             'ArgumentList',
-                                                                            $ArgumentList, 
+                                                                            $ArgumentListReport, 
                                                                             $true
                                                                         )
                                                                     )

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.23
+Version: 1.1.231
 Author: Tydeno
 
 .DESCRIPTION
@@ -2515,7 +2515,7 @@ function Move-PlotoPlots
         } 
  
 $DestinationDrives = Get-PlotoOutDrives -Mover $true
-$PlotsToMove = Get-PlotoPlots -mover $true
+$PlotsToMove = Get-PlotoPlots
 
 Write-Host "PlotoMover @"(Get-Date)": Checking if we have any plots to move..." 
 

--- a/Ploto.psm1
+++ b/Ploto.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Name: Ploto
 
-Version: 1.1.232
+Version: 1.1.233
 Author: Tydeno
 
 .DESCRIPTION
@@ -3075,7 +3075,7 @@ catch
          exit
     } 
 
-$ReplotDriveDenom = $config.DiskConfig.DenomForOutDrivesToReplotForPools
+$ReplotDriveDenom = $config.DiskConfig.ReplotDrives
 
 $count = 0
     for ($count -lt 100000000000)

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -21,6 +21,7 @@
     "SpawnerConfig":  [
                           {
                               "ReplotForPool":  "false",
+                              "ReplotPlotsOlderThan": "18.6.2021",
                               "IntervallToCheckInMinutes":  "1",
                               "InputAmountToSpawn":  "50",
                               "WaitTimeBetweenPlotOnSeparateDisks":  "1",

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -6,6 +6,8 @@
   "EnablePlotoFyOnStart": "true",
   "ChiaWindowStyle": "normal",
   "PathToPloto": "C:/Users/Tydeno/Desktop/Ploto/Ploto.psm1",
+  "EnableMover": "true",
+  "PathsToMovePlotsTo",
 
   "DiskConfig": [
     {

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -7,7 +7,7 @@
   "ChiaWindowStyle": "normal",
   "PathToPloto": "C:/Users/Tydeno/Desktop/Ploto/Ploto.psm1",
   "EnableMover": "true",
-  "PathsToMovePlotsTo",
+  "PathsToMovePlotsTo": "E:\\,P:\\",
 
   "DiskConfig": [
     {

--- a/PlotoSpawnerConfig.json
+++ b/PlotoSpawnerConfig.json
@@ -1,59 +1,56 @@
 {
-  "PlotterName": "SirNotPlotAlot",
-  "PlotterUsed": "Stotik",
-  "PathToUnofficialPlotter": "...\\chia_plot.exe",
-  "EnableAlerts": "false",
-  "EnablePlotoFyOnStart": "true",
-  "ChiaWindowStyle": "normal",
-  "PathToPloto": "C:/Users/Tydeno/Desktop/Ploto/Ploto.psm1",
-  "EnableMover": "true",
-  "PathsToMovePlotsTo": "E:\\,P:\\",
+    "PlotterName":  "plotozero",
+    "PlotterUsed":  "Stotik",
+    "PathToUnofficialPlotter":  "C:\\Users\\Tydeno\\Desktop\\madMAx43v3r_chia-plotter_win_build_v0.0.4\\chia_plot.exe",
+    "EnableAlerts":  "true",
+    "EnablePlotoFyOnStart":  "true",
+    "ChiaWindowStyle":  "normal",
+    "PathToPloto":  "C:\\Users\\Tydeno\\Desktop\\Ploto\\Ploto.psm1",
+    "EnableMover": "true",
+    "PathsToMovePlotsTo": "Q:\\Plotter,Z:",
 
-  "DiskConfig": [
-    {
-      "TempDrives": "E:\\,P:\\",
-      "Temp2Drives": "K:\\Plotter",
-      "OutDrives": "",
-      "EnableT2": "false",
-      "ReplotDrives": ""
-    }
-  ],
-
-  "SpawnerConfig": [
-      {
-        "ReplotForPool": "false",
-        "IntervallToCheckInMinutes": "5",
-        "InputAmountToSpawn": "100", 
-        "WaitTimeBetweenPlotOnSeparateDisks": "15",
-        "WaitTimeBetweenPlotOnSameDisk": "30",
-        "MaxParallelJobsOnAllDisks": "8",
-        "MaxParallelJobsOnSameDisk": "2",
-        "MaxParallelJobsInPhase1OnAllDisks" : "4",
-        "StartEarly": "true",
-        "StartEarlyPhase": "4"
-      }
-    ],
-
-  "JobConfig": [
-      {
-        "KSizeToPlot": "32",
-        "BufferSize": "",
-        "Thread": "4",
-        "Buckets": "128",
-        "Bitfield": "true",
-        "FarmerKey": "",
-        "PoolKey": "",
-        "P2SingletonAdress": ""
-      }
-    ],
-
-  "SpawnerAlerts": [
-    {
-      "DiscordWebhookURL": "https://discord.com/api/webhooks/xxxxxxxxxxxxxxxx",
-      "WhenJobSpawned": "true",
-      "WhenNoOutDrivesAvailable": "true",
-      "WhenJobCouldNotBeSpawned": "true",
-      "PeriodOfReportInHours": "1"
-    }
-  ]
+    "DiskConfig":  [
+                       {
+                           "TempDrives":  "F:",
+                           "Temp2Drives":  "J:",
+                           "OutDrives":  "L:,K:",
+                           "EnableT2":  "true",
+                           "ReplotDrives":  ""
+                       }
+                   ],
+    "SpawnerConfig":  [
+                          {
+                              "ReplotForPool":  "false",
+                              "IntervallToCheckInMinutes":  "1",
+                              "InputAmountToSpawn":  "50",
+                              "WaitTimeBetweenPlotOnSeparateDisks":  "1",
+                              "WaitTimeBetweenPlotOnSameDisk":  "1",
+                              "MaxParallelJobsOnAllDisks":  "1",
+                              "MaxParallelJobsOnSameDisk":  "1",
+                              "MaxParallelJobsInPhase1OnAllDisks":  "1",
+                              "StartEarly":  "false",
+                              "StartEarlyPhase":  "4"
+                          }
+                      ],
+    "JobConfig":  [
+                      {
+                          "KSizeToPlot":  "32",
+                          "BufferSize":  "",
+                          "Thread":  "24",
+                          "Buckets":  "256",
+                          "Bitfield":  "false",
+                          "FarmerKey":  "YourKey",
+                          "PoolKey":  "YourKey",
+                          "P2SingletonAdress":  ""
+                      }
+                  ],
+    "SpawnerAlerts":  [
+                          {
+                              "DiscordWebhookURL":  "https://discord.com/api/webhooks/YourcustomURLWebhookEnding",
+                              "WhenJobSpawned":  "true",
+                              "WhenNoOutDrivesAvailable":  "true",
+                              "WhenJobCouldNotBeSpawned":  "true",
+                              "PeriodOfReportInHours":  "0.5"
+                          }
+                      ]
 }

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Be advises that this in BETA mode right now.
 
 To create portable pool plots, we need to use the param "P2Singleton" in the config. 
 Therefore we need to create a singleton that points to a pool first, and then we can start plotting. 
-If you want to plot portable pools, make sure your PoolKey is NOT specified in the config, as this will mess thing up
+If you want to plot portable pools, make sure your PoolKey is NOT specified in the config, as this will mess thing up.
 
 ### About replotting
 Ploto now supports the ability to replot existing drives. This assumes you have one or more drives with final plots that are actively being farmed.
@@ -136,6 +136,9 @@ If you now launch Ploto with 'Replot: "true"' and your denom for your ReplotDriv
 2. If there is a job entering phase 4 with "IsReplot=True", it deletes the oldest plot on the drive, the replotJob uses as OutDrive.
 
 All ReplotJobs launchd, will use the the drives as OutDrive, that match the ReplotDriveDenom. So if you replot, make sure you set the InputAmountToSpawn to exactly the number of Plots you want to Replot. Currently Ploto does not know with which keys/singletons a Plot was plotted. So it keeps going and potentially deletes already replotted jobs, if InputAmountToSpawn is too high. This can lead to unneccesary wear & tear.
+
+The replotting mechanism features a * `"ReplotPlotsOlderThan": "20.6.2021` parameter in config. It allows you to define which plots shall be replotted and which not by specifying a date as seen above. This is a mandatory param if you want to replot, as its the only way to determine which plots shall be replotted
+It picks those drives that have final plots on it for replotting. If there is no drive that has plots to replot, its chooses the best suited OutDrive by free space. If there is none, it aborts. 
 
 ## About running custom plotters
 Ploto now supports custom plotters. This functionality was implemented to support madMAx43v3r's chia-plotter. It also allows to use sever other forks, like Stotiks and catchmeifyoucans release.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,12 @@
 ## Ploto 
 An easy to use, customizable and heavily reliable Windows PowerShell based Chia Plotting Manager. 
 
-## Features at a glance
-* Customizable Plotter to be used; Supports madmax/stotiks and official chia plotter
-* Allows for staggering on several levels;
-  * By Minutes to be waited between each job on the same or separate disk
-  * When a jobs enters a customizable phase (say 4), it kicks off a new job
-  * By limiting amount of max concurrent plots on a single disk, all disks and in phase 1
-* Replotting mechanism;
-  * Define the drives you want to replot and Ploto will gradually replace the plots in those drives with new plots
-  * When a plot that targets a drive to replot is about to enter phase 4, it deletes the oldest plot on the defined drive.  
-* Supports Pool plotting (-c p2singleton and -f params)
-* Automatically starts Jobs on the speediest drive with the least jobs on it
-* Can stop a Plot job and automatically deletes .tmp and . log files
-* Removes aborted jobs automatically and it its leftovers (.tmp and .log files)
-* Can automatically move finished plots to a UNC path or other drive
-* Sends you Discord notification about whats going on with your plotting. Customize what notifications you want to receive;
-  * When a new plot job is spawned
-  * When a plot job aborts
-  * A Summary in customizable intervall about whats going on with your plotting (Jobs in progress and completed jobs)
-  * When there is no plot job going around
+
+![image](https://user-images.githubusercontent.com/83050419/123462242-57fa0a00-d5ea-11eb-9506-03cb578ce77d.png)
+
+![image](https://user-images.githubusercontent.com/83050419/123462300-6c3e0700-d5ea-11eb-9c2f-f5915c758580.png)
+
+
 
 
 # Table of content
@@ -222,11 +209,7 @@ PlotoManager @ 4/30/2021 3:49:13 AM : Overall spawned Plots since start of scrip
 
 ## How to get Jobs
 1. Open another PowerShell session 
-2. Import-Module "Ploto" 
-```powershell
-Import-Module "C:\Users\Me\Downloads\Ploto\Ploto.psm1"
-```
-4. Launch Get-PlotoJobs and format Output
+2. Launch Get-PlotoJobs and format Output
 ```powershell
 Get-PlotoJobs | ft
 ```
@@ -364,34 +347,11 @@ This is only possible as I continously move the final Plots to my farming machin
 
 I do this by moving plots to a external drive and plug that into my farmer, and sometimes I also transfer plots across my network (not the fatest, thats why I kind of have to do  the running around approach)
 
-PlotoMover helps to automate this process.
+PlotoMover helps to automate this process. In PlotoSpawnerConfig.json, you can define several drives you want to move your final plots to. Mover then checks all defined outdrives for final plots and moves one by one trough Background Inteligence Transfer Service (BITS) to the desired location. In order for remote destination targets (your farmers/harvesters) to recognized correctly, these drives needed to be mapped as network drives and have a volume letter assigned (eg Z:\) for mover to tbe able to grab them.
 
-If you want to move your plots to a local/external drive just once:
-1. Launch a PowerShell session and Import Ploto Module
-2. Launch Move-PlotoPLots
+To enable mover,, in the config set EnablerMover to "true" and define the PathsToMovePlotsTo according the example config.
+Then the next time you launch `Start-PlotoSpawns` mover will be launched aswell.
 
-```powershell
-Move-PlotoPlots -DestinationDrive "P:" -OutDriveDenom "out" -TransferMethod Move-Item
-```
-
-If you want to move your plots to a UNC path just once:
-1. Launch a PowerShell session and Import Ploto Module
-2. Launch Move-PlotoPLots
-
-```powershell
-Move-PlotoPlots -DestinationDrive "\\Desktop-xxxxx\d" -OutDriveDenom "out" -TransferMethod Move-Item
-```
-
-Please be aware that if you use UNC paths as Destination, PlotoMover cannot grab the free space there and just fires off.
-
-## But I want to do it continously
-Sure, just use Start-PlotoMove with your needed params:
-
-```powershell
-Move-PlotoPlots -DestinationDrive "\\Desktop-xxxxx\d" -OutDriveDenom "out" -TransferMethod Move-Item
-```
-
-Please be aware that if you use UNC paths as Destination, PlotoMover cannot grab the free space there and just fires off.
 
 ## How to Check Farm Logs
 If you want to peek at your farm logs you can use Check-PLotoFarmLogs:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
-## Ploto 
+## [Ploto](https://www.ploto.rocks)
 An easy to use, customizable and heavily reliable Windows PowerShell based Chia Plotting Manager. 
 
 
 ![image](https://user-images.githubusercontent.com/83050419/123462242-57fa0a00-d5ea-11eb-9506-03cb578ce77d.png)
-
 ![image](https://user-images.githubusercontent.com/83050419/123462300-6c3e0700-d5ea-11eb-9c2f-f5915c758580.png)
-
-
-
 
 # Table of content
 * [Contact](https://github.com/tydeno/Ploto/tree/main#contact)
@@ -33,6 +29,8 @@ An easy to use, customizable and heavily reliable Windows PowerShell based Chia 
 * [FAQ](https://github.com/tydeno/Ploto/tree/main#faq)
 
 ## Contact
+https://www.ploto.rocks/
+
 For general chatting, issues and support of how to use Ploto, you may join the Discord below.
 If you find any bugs, do not hesitate to create or update an issue directly here in GitHub.
 

--- a/README.md
+++ b/README.md
@@ -44,23 +44,6 @@ In case you'd like to to support the development of Ploto in a monetary way, you
 
 Or trough my [GitHub Sponsoring page](https://github.com/sponsors/tydeno)
 
-## Is it safe to use? 
-We've seen some horrific stuff happening with 3rd Party Tools around a Chia. For instance
-there was/is a PowerShell Script that should add some Introducers to your farm. It does that yes. But it also empties your wallet and sends your private keys home.
-
-This was a good reminder that we should never trust blindly on the internet (and everywhere else!).
-Never trust, always verify is the leading principle. 
-
-So I encourage you to go trough the code in this repo, line by line to verify if it does something bad.
-If theres a line you don't understand do not hesitate to raise an issue and ask straight away.
-
-However, bear in mind that my identity is verified by Github trough the sponsoring program. They have my adress, tax and ID number and thus know exactly who I am. Doing bad things with my repo would be a very bad idea in that sense for myself.
-
-From a technical perspective, if you are cooncerned that your private keys and or wallet might be exposed to Ploto, you can mitigate that.
-Ploto only needs chia.exe to start PlotJobs. No private keys, no access to farmers/harvesters nor a wallet.
-If you run Ploto on dedicated plotting machines, you can specify your public keys in the config and generate valid plots for your farm.
-
-On top of that; it always makes sense to set your reward address to a cold wallet.
 
 # PlotoSpawn
 TLDR: It plots 1x plot on each TempDrive (if you have 6x TempDrives = 6x parallel Plot Jobs) as long as you want it to and as long as you have OutDrive space.
@@ -394,7 +377,6 @@ So what works for me, may not ultimately work for you.
 Please also bear in mind that unexpected beahviour and or bugs are possible.
 
 These are known:
-* Only works when plotting in root of drives
 * Only works when Drives are dedicated to plotting (dont hold any other files)
 * If you start to use Ploto and you have Logs created by GUI or any other manager in C:\Users\me.chia\mainnet\plotter\, Get-PlotoPlots wont the able to read the status.
 Make sure you delete/move all existing Logs in said path. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ## Ploto 
 An easy to use, customizable and heavily reliable Windows PowerShell based Chia Plotting Manager. 
-Consists of a PowerShell Module that allows to spawn, manage and move plots.
 
 ## Features at a glance
 * Customizable Plotter to be used; Supports madmax/stotiks and official chia plotter

--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
 ## Ploto 
-A Windows PowerShell based Chia Plotting Manager. 
+An easy to use, customizable and heavily reliable Windows PowerShell based Chia Plotting Manager. 
 Consists of a PowerShell Module that allows to spawn, manage and move plots.
 
-Also informs you in Discord about spawned jobs. 
-And if you like, you may define an Intervall upon which Plotofy sends you notifications about whats going on.
-
-
-![image](https://user-images.githubusercontent.com/83050419/119401060-4536a180-bcdb-11eb-8bb5-fa587b229d59.png)
-
-![image](https://user-images.githubusercontent.com/83050419/118192418-662f0500-b446-11eb-9340-e919234d3d5f.png)
-![image](https://user-images.githubusercontent.com/83050419/118396387-a57c7200-b64f-11eb-8ef5-0526bd8cb3c6.png)
-![image](https://user-images.githubusercontent.com/83050419/118396379-9eedfa80-b64f-11eb-9a83-1262a6625f3a.png)
-
-![image](https://user-images.githubusercontent.com/83050419/118398002-f479d580-b656-11eb-82f7-a92a4a0af4a9.png)
-
+## Features at a glance
+* Customizable Plotter to be used; Supports madmax/stotiks and official chia plotter
+* Allows for staggering on several levels;
+  * By Minutes to be waited between each job on the same or separate disk
+  * When a jobs enters a customizable phase (say 4), it kicks off a new job
+  * By limiting amount of max concurrent plots on a single disk, all disks and in phase 1
+* Replotting mechanism;
+  * Define the drives you want to replot and Ploto will gradually replace the plots in those drives with new plots
+  * When a plot that targets a drive to replot is about to enter phase 4, it deletes the oldest plot on the defined drive.  
+* Supports Pool plotting (-c p2singleton and -f params)
+* Automatically starts Jobs on the speediest drive with the least jobs on it
+* Can stop a Plot job and automatically deletes .tmp and . log files
+* Removes aborted jobs automatically and it its leftovers (.tmp and .log files)
+* Can automatically move finished plots to a UNC path or other drive
+* Sends you Discord notification about whats going on with your plotting. Customize what notifications you want to receive;
+  * When a new plot job is spawned
+  * When a plot job aborts
+  * A Summary in customizable intervall about whats going on with your plotting (Jobs in progress and completed jobs)
+  * When there is no plot job going around
 
 
 # Table of content


### PR DESCRIPTION
This PR focusses on bringing PlotoMover into the PlotoSpawnerConfig.json aswell and make it startable upon launch. Until now, it was necessary to start another PowerShell Session to fire up PlotoMover. Alongside that, it now also supports MountPoints and Network drives! It also brings some new capabilities within the replot mechanism.

## Added
* Support MountPoints as OutDrives; Ploto now support the use of MountPoints as outdrives and final drives for mover.
* Support of Network Drives as OutDrives; Ploto now support the use of Network drives as outdrives and final drives for mover
* `"ReplotPlotsOlderThan": "20.6.2021` in config parameter. Allows you to define which plots shall be replotted and which not by specifying a date as seen above. This is a mandatory param if you want to replot, as its the only way to determine which plots shall be replotted
* Replot mechanism now picks those drives that have final plots on it for replotting. If there is no drive that has plots to replot, its chooses the best suited OutDrive by free space. If there is none, it aborts. 
* Mover is now able to handle several final drives. If there are more than 1 final drives, it picks the one that has no BITS Transfers in progress. If there are non with BITS Transfer in progress, it selects the one with the most available space.

## Changed
* PlotoMover cannot be started anymore with params. It uses definable Drives and Paths in config. closes #98 
* Changed some outputs to proper meaning and source (function)
* Mover now solely relies on BITS to transfer plots
* Mover now transfer plots async and waits 30 minutes between each move of a plot
* mover ignores plotsolderthan to be moved if replot enabled
* reduced sleep of Watchdog intervall to check for jobs to 1 minute instead of 5

## Fixed
* An issue where -p and -f were not ommitted correctly. closes #93 
* A couple of potential bugs